### PR TITLE
Fix LDFLAGS propagation in valabind-cc.

### DIFF
--- a/valabind-cc
+++ b/valabind-cc
@@ -111,7 +111,7 @@ guile)
   ;;
 python)
   use_cxx
-  LDFLAGS="-L/usr/local/lib -L/usr/pkg/lib"
+  LDFLAGS="${LDFLAGS} -L/usr/local/lib -L/usr/pkg/lib"
   if [ -n "`echo ${CXX} | grep mingw`" ]; then
     CFLAGS="${CFLAGS} -I${HOME}/.wine/drive_c/Python27/include"
     LDFLAGS="${LDFLAGS} -L${HOME}/.wine/drive_c/Python27/libs -lpython27"
@@ -159,7 +159,7 @@ java)
   ;;
 php5)
   CFLAGS="`php-config --includes 2>/dev/null` `pkg-config --libs libpng 2>/dev/null`"
-  LDFLAGS=`php-config --libs 2>/dev/null`
+  LDFLAGS="${LDFLAGS} `php-config --libs 2>/dev/null`"
   ;;
 lua)
   SOEXT=so


### PR DESCRIPTION
LDFLAGS are not properly propagated in valabind-cc for python and php5 bindings.
