### PR TITLE
probably fixes handling of dependencies in ctypeswriter

### DIFF
--- a/ctypeswriter.vala
+++ b/ctypeswriter.vala
@@ -409,6 +409,7 @@ n++;
 			if (!array.fixed_length)
 				field = element + "* " + f.name; // FIXME should this be element+"[]"?
 			field = "'%s', %s * %d".printf (f.name, element, array.length);
+            stype = element;
 		} else {
 			/* HACK to support generics. this is r2 specific */
 			if (stype.index_of ("RListIter") != -1) {


### PR DESCRIPTION
This fixed the wrong dependencies for ctypes. All tests pass fine with it.
However I didn't read through all of the code, so this change might as well be completely wrong.
