### PR TITLE
Fix `getvv` on MacOS X Lion

### DIFF
--- a/getvv
+++ b/getvv
@@ -3,7 +3,7 @@ IFS=:
 [ -z "${VALAC}" ] && VALAC=valac
 for a in $PATH; do
 	if [ -e "$a/valac" ]; then
-		v=$(strings $a/${VALAC} | grep vala- | grep -v lib)
+		v=$(cat $a/${VALAC} | strings | grep vala- | grep -v lib)
 		if [ -n "$v" ]; then
 			printf lib$v
 			exit 0


### PR DESCRIPTION
When passing an executable file as an argument to `strings` it will
attempt to parse its headers in order to only look for strings in the
"appropriate" sections.  As I don't have direct access to a Lion machine
I have not been able to perform a deep analysis but it appears that on
Lion the "current" version of XCode produces Mach-O headers that are
incompatible with Lion's "current" version of `strings`.  By cat:ing the
binary and filtering it through `strings` the header parsing is bypassed
and all goes well.

Without this patch the following error message is produced:

```
strings: object: /usr/local/opt/vala/bin/valac malformed object (unknown load command 17)
```
