### PR TITLE
gir: Fix constant generation

### DIFF
--- a/girwriter.vala
+++ b/girwriter.vala
@@ -189,7 +189,7 @@ public class GirWriter : ValabindWriter {
 		var ctype = get_ctype (f.type_reference.to_string ());
 		var gtype = girtype (f.type_reference.to_string ());
 		extends += "<constant name=\""+cname+"\" value=\""+cvalue+"\">\n";
-		extends += "  <type name="+gtype+" c:type=\""+ctype+"\">\n";
+		extends += "  <type name=\""+gtype+"\" c:type=\""+ctype+"\"/>\n";
 		extends += "</constant>\n";
 		//extends += "static const char *"+f.name+" = "+cname+";\n";
 	}

--- a/girwriter.vala
+++ b/girwriter.vala
@@ -20,10 +20,6 @@ public class GirWriter : ValabindWriter {
 		return base_name+".gir";
 	}
 
-	public override void write(string file) {
-		context.accept (this);
-	}
-
 	string get_alias (string name) {
 		string oname = name;
 		switch (name) {
@@ -381,7 +377,7 @@ public class GirWriter : ValabindWriter {
 //externs += "</namespace>\n";
 	}
 
-	public void write_file (string file) {
+	public override void write(string file) {
 		var stream = FileStream.open (file, "w");
 		if (stream == null)
 			error ("Cannot open %s for writing".printf (file));


### PR DESCRIPTION
The creation of constants has a syntax error, on the one hand the `type` tag did not have a closing tag and on the other hand the `name` attribute was not enclosed in quotes.

Before:
```xml
    <constant name="RE_SYNTAX_EMACS" value="TODO">
      <type name=Posix.RegexSyntax c:type="PosixRegexSyntax">
    </constant>
```

After:
```xml
    <constant name="RE_SYNTAX_EMACS" value="TODO">
      <type name="Posix.RegexSyntax" c:type="PosixRegexSyntax" />
    </constant>
```

~This PR includes #58~